### PR TITLE
Use b4a.equals in key check in firewall

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = class Hyperbeam extends Duplex {
     if (this.announce) {
       this._server = this._node.createServer({
         firewall (remotePublicKey) {
-          return !remotePublicKey.equals(keyPair.publicKey)
+          return !b4a.equals(remotePublicKey, keyPair.publicKey)
         }
       })
       this._server.on('connection', onConnection)


### PR DESCRIPTION
Trying hyperbeam in browser, this the only thing that stops it.